### PR TITLE
package-management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ yarn-error.log*
 !/dist_electron/certs/*
 !/dist_electron/entitlements.mac.plist
 !/dist_electron/notarize.js
+
+# yarn lock
+yarn.lock


### PR DESCRIPTION
Ignore yarn.lock by default, since you don't want to commit it anyways. :P