### PR TITLE
Tor for linux

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1,7 +1,5 @@
 'use strict'
 
-import path from 'path'
-import fs from 'fs'
 import { app, protocol, nativeTheme, BrowserWindow, Menu } from 'electron'
 import { autoUpdater } from 'electron-updater'
 import { createProtocol, installVueDevtools } from 'vue-cli-plugin-electron-builder/lib'


### PR DESCRIPTION
Aight there were some hickups when starting tor on linux but that has been fixed by statically linking the libraries to the executable.